### PR TITLE
[error_diffuse] don't diffuse into the void

### DIFF
--- a/src/quant.c
+++ b/src/quant.c
@@ -853,14 +853,19 @@ end:
 
 /* diffuse error energy to surround pixels */
 static void
-error_diffuse(unsigned char /* in */    *data,      /* base address of pixel buffer */
-              int           /* in */    pos,        /* address of the destination pixel */
-              int           /* in */    depth,      /* color depth in bytes */
-              int           /* in */    error,      /* error energy */
-              int           /* in */    numerator,  /* numerator of diffusion coefficient */
-              int           /* in */    denominator /* denominator of diffusion coefficient */)
+error_diffuse(unsigned char /* in */    *data,       /* base address of pixel buffer */
+              int           /* in */    pos,         /* address of the destination pixel */
+              int           /* in */    depth,       /* color depth in bytes */
+              int           /* in */    error,       /* error energy */
+              int           /* in */    numerator,   /* numerator of diffusion coefficient */
+              int           /* in */    denominator ,/* denominator of diffusion coefficient */
+              int           /* in */    area         /* area, in pixels */)
 {
     int c;
+
+    if (pos < 0 || pos >= area) {
+        return;
+    }
 
     data += pos * depth;
 
@@ -903,13 +908,13 @@ diffuse_fs(unsigned char *data, int width, int height,
      */
     if (x < width - 1 && y < height - 1) {
         /* add error to the right cell */
-        error_diffuse(data, pos + width * 0 + 1, depth, error, 7, 16);
+        error_diffuse(data, pos + width * 0 + 1, depth, error, 7, 16, width * height);
         /* add error to the left-bottom cell */
-        error_diffuse(data, pos + width * 1 - 1, depth, error, 3, 16);
+        error_diffuse(data, pos + width * 1 - 1, depth, error, 3, 16, width * height);
         /* add error to the bottom cell */
-        error_diffuse(data, pos + width * 1 + 0, depth, error, 5, 16);
+        error_diffuse(data, pos + width * 1 + 0, depth, error, 5, 16, width * height);
         /* add error to the right-bottom cell */
-        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 16);
+        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 16, width * height);
     }
 }
 
@@ -929,17 +934,17 @@ diffuse_atkinson(unsigned char *data, int width, int height,
      */
     if (y < height - 2) {
         /* add error to the right cell */
-        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 8, width * height);
         /* add error to the 2th right cell */
-        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 8, width * height);
         /* add error to the left-bottom cell */
-        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 8, width * height);
         /* add error to the bottom cell */
-        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 8, width * height);
         /* add error to the right-bottom cell */
-        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 8, width * height);
         /* add error to the 2th bottom cell */
-        error_diffuse(data, pos + width * 2 + 0, depth, error, 1, 8);
+        error_diffuse(data, pos + width * 2 + 0, depth, error, 1, 8, width * height);
     }
 }
 
@@ -958,18 +963,18 @@ diffuse_jajuni(unsigned char *data, int width, int height,
      *  1/48    3/48    5/48    3/48    1/48
      */
     if (pos < (height - 2) * width - 2) {
-        error_diffuse(data, pos + width * 0 + 1, depth, error, 7, 48);
-        error_diffuse(data, pos + width * 0 + 2, depth, error, 5, 48);
-        error_diffuse(data, pos + width * 1 - 2, depth, error, 3, 48);
-        error_diffuse(data, pos + width * 1 - 1, depth, error, 5, 48);
-        error_diffuse(data, pos + width * 1 + 0, depth, error, 7, 48);
-        error_diffuse(data, pos + width * 1 + 1, depth, error, 5, 48);
-        error_diffuse(data, pos + width * 1 + 2, depth, error, 3, 48);
-        error_diffuse(data, pos + width * 2 - 2, depth, error, 1, 48);
-        error_diffuse(data, pos + width * 2 - 1, depth, error, 3, 48);
-        error_diffuse(data, pos + width * 2 + 0, depth, error, 5, 48);
-        error_diffuse(data, pos + width * 2 + 1, depth, error, 3, 48);
-        error_diffuse(data, pos + width * 2 + 2, depth, error, 1, 48);
+        error_diffuse(data, pos + width * 0 + 1, depth, error, 7, 48, width * height);
+        error_diffuse(data, pos + width * 0 + 2, depth, error, 5, 48, width * height);
+        error_diffuse(data, pos + width * 1 - 2, depth, error, 3, 48, width * height);
+        error_diffuse(data, pos + width * 1 - 1, depth, error, 5, 48, width * height);
+        error_diffuse(data, pos + width * 1 + 0, depth, error, 7, 48, width * height);
+        error_diffuse(data, pos + width * 1 + 1, depth, error, 5, 48, width * height);
+        error_diffuse(data, pos + width * 1 + 2, depth, error, 3, 48, width * height);
+        error_diffuse(data, pos + width * 2 - 2, depth, error, 1, 48, width * height);
+        error_diffuse(data, pos + width * 2 - 1, depth, error, 3, 48, width * height);
+        error_diffuse(data, pos + width * 2 + 0, depth, error, 5, 48, width * height);
+        error_diffuse(data, pos + width * 2 + 1, depth, error, 3, 48, width * height);
+        error_diffuse(data, pos + width * 2 + 2, depth, error, 1, 48, width * height);
     }
 }
 
@@ -988,18 +993,18 @@ diffuse_stucki(unsigned char *data, int width, int height,
      *  1/48    2/48    4/48    2/48    1/48
      */
     if (pos < (height - 2) * width - 2) {
-        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 6);
-        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 12);
-        error_diffuse(data, pos + width * 1 - 2, depth, error, 1, 24);
-        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 12);
-        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 6);
-        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 12);
-        error_diffuse(data, pos + width * 1 + 2, depth, error, 1, 24);
-        error_diffuse(data, pos + width * 2 - 2, depth, error, 1, 48);
-        error_diffuse(data, pos + width * 2 - 1, depth, error, 1, 24);
-        error_diffuse(data, pos + width * 2 + 0, depth, error, 1, 12);
-        error_diffuse(data, pos + width * 2 + 1, depth, error, 1, 24);
-        error_diffuse(data, pos + width * 2 + 2, depth, error, 1, 48);
+        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 6, width * height);
+        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 12, width * height);
+        error_diffuse(data, pos + width * 1 - 2, depth, error, 1, 24, width * height);
+        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 12, width * height);
+        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 6, width * height);
+        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 12, width * height);
+        error_diffuse(data, pos + width * 1 + 2, depth, error, 1, 24, width * height);
+        error_diffuse(data, pos + width * 2 - 2, depth, error, 1, 48, width * height);
+        error_diffuse(data, pos + width * 2 - 1, depth, error, 1, 24, width * height);
+        error_diffuse(data, pos + width * 2 + 0, depth, error, 1, 12, width * height);
+        error_diffuse(data, pos + width * 2 + 1, depth, error, 1, 24, width * height);
+        error_diffuse(data, pos + width * 2 + 2, depth, error, 1, 48, width * height);
     }
 }
 
@@ -1017,13 +1022,13 @@ diffuse_burkes(unsigned char *data, int width, int height,
      *  1/16    2/16    4/16    2/16    1/16
      */
     if (pos < (height - 1) * width - 2) {
-        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 4);
-        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 8);
-        error_diffuse(data, pos + width * 1 - 2, depth, error, 1, 16);
-        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 8);
-        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 4);
-        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 8);
-        error_diffuse(data, pos + width * 1 + 2, depth, error, 1, 16);
+        error_diffuse(data, pos + width * 0 + 1, depth, error, 1, 4, width * height);
+        error_diffuse(data, pos + width * 0 + 2, depth, error, 1, 8, width * height);
+        error_diffuse(data, pos + width * 1 - 2, depth, error, 1, 16, width * height);
+        error_diffuse(data, pos + width * 1 - 1, depth, error, 1, 8, width * height);
+        error_diffuse(data, pos + width * 1 + 0, depth, error, 1, 4, width * height);
+        error_diffuse(data, pos + width * 1 + 1, depth, error, 1, 8, width * height);
+        error_diffuse(data, pos + width * 1 + 2, depth, error, 1, 16, width * height);
     }
 }
 


### PR DESCRIPTION
Fixes the invalid accesses noted by @a4865g in #25. Simple and inelegant, but robust fix. Closes #25.