### PR TITLE
sixel_encoder_prepare_palette: kill use-after-free

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -560,7 +560,6 @@ sixel_encoder_prepare_palette(
                                      encoder->method_for_rep,
                                      encoder->quality_mode);
     if (SIXEL_FAILED(status)) {
-        sixel_dither_unref(*dither);
         goto end;
     }
 


### PR DESCRIPTION
The only place sixel_encoder_prepare_palette() is called from is sixel_encoder_encode_frame(). If we have a SIXEL_FAILED result inside the former, we unref the palette, potentially freeing it. We then goto the error path for
sixel_encoder_encode_frame(), where we unref it again, in a classic double-free. Remove the internal unref. As noted,
this is a single call site, so removing the unref can't cause a memory leak.

Closes #27, reported by a4865g ("WuLearn").