### PR TITLE
Set SONAME, build static library #37

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,11 @@ sources = [
   'writer.c'
 ]
 
-libsixel = shared_library('sixel', sources, include_directories: [inc, inc_config], dependencies: libsixel_deps, install: true)
+libsixel = both_libraries('sixel',
+  sources,
+  include_directories: [inc, inc_config],
+  dependencies: libsixel_deps,
+  version: '1.0.0',
+  install: true)
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(libsixel, name: 'libsixel', description: pkg_description, libraries: '-lsixel')


### PR DESCRIPTION
Build static library. Set SONAME on shared library (`libsixel.1`). Closes #37 .