### PR TITLE
no need for sys/unistd.h

### DIFF
--- a/converters/img2sixel.c
+++ b/converters/img2sixel.c
@@ -28,7 +28,6 @@
 #include <string.h>
 
 # include <unistd.h>
-# include <sys/unistd.h>
 #include <sys/types.h>
 # include <getopt.h>
 # include <inttypes.h>

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,6 @@ needed_headers = [
   'string.h',
   'unistd.h',
   'stdint.h',
-  'sys/unistd.h',
   'getopt.h',
   'sys/types.h',
   'sys/stat.h',

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -26,7 +26,6 @@
 # include <stdarg.h>
 # include <string.h>
 # include <unistd.h>
-# include <sys/unistd.h>
 #include <sys/types.h>
 #include <sys/select.h>
 # include <time.h>

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -27,7 +27,6 @@
 # include <stdarg.h>
 #include <string.h>
 # include <unistd.h>
-# include <sys/unistd.h>
 # include <sys/types.h>
 # include <time.h>
 # include <sys/time.h>

--- a/src/tty.c
+++ b/src/tty.c
@@ -28,7 +28,6 @@
 # include <sys/time.h>
 # include <sys/types.h>
 # include <unistd.h>
-# include <sys/unistd.h>
 # include <sys/select.h>
 # include <errno.h>
 # include <termios.h>


### PR DESCRIPTION
Stop trying to include `sys/unistd.h`, unavailable on musl.