### PR TITLE
Update python bindings to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,8 @@ before_install:
   - "if [ x$TRAVIS_OS_NAME = xlinux -a x$XCC = xx86_64-w64-mingw32-gcc ]; then sudo apt-get install -qq gcc-mingw-w64-x86-64 binutils-mingw-w64-x86-64; fi"
   - "if [ x$TRAVIS_OS_NAME = xlinux -a x$GCOV != x ]; then sudo apt-get install libyaml-dev; fi"
   - "if [ x$TRAVIS_OS_NAME = xosx -a x$GCOV != x ]; then brew install libyaml; fi"
-  - "if [ x$TRAVIS_OS_NAME = xlinux -a x$GCOV != x ]; then sudo pip install cpp-coveralls pyyaml; fi"
-  - "if [ x$TRAVIS_OS_NAME = xosx -a x$GCOV != x ]; then pip install cpp-coveralls pyyaml; fi"
+  - "if [ x$TRAVIS_OS_NAME = xlinux -a x$GCOV != x ]; then sudo pip3 install cpp-coveralls pyyaml; fi"
+  - "if [ x$TRAVIS_OS_NAME = xosx -a x$GCOV != x ]; then pip3 install cpp-coveralls pyyaml; fi"
 
 before_script:
   - "CC=$XCC ./configure --prefix=${PREFIX} ${DEBUG} ${HOST} ${GDKPIXBUF} ${GD} ${LIBCURL} ${PNG} ${JPEG} ${GCOV} ${STATIC}"

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+* libsixel 1.10.2 (2021-10-01)
+ * new maintainer, @wsluser
+ * Update python bindings to use python3. Python 3.9 is preferred. File issues
+   if bugs are found in python 3.6-8.
+   
 * libsixel 1.10.1 (2021-09-18)
  * new maintainer, nick black <dankamongmen@gmail.com>
  * fix two use-after-free()s, one found by @a4865g ("WuLearn") and one

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,6 @@
-* libsixel 1.10.2 (2021-10-01)
- * new maintainer, @wsluser
+* libsixel 1.10.2 (2021-10-08)
  * Update python bindings to use python3. Python 3.9 is preferred. File issues
-   if bugs are found in python 3.6-8.
+   if bugs are found in python 3.6-8. Thanks, @wsluser
    
 * libsixel 1.10.1 (2021-09-18)
  * new maintainer, nick black <dankamongmen@gmail.com>

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ You can use the following options at build time to influence the build. During t
 |png|`--with-png`|Whether to build with libpng support|Auto|
 |gcov|`--enable-gcov`|Build gcov coverage tests|No|
 |tests|`--enable-tests`|Build tests (requires `bash`)|No|
-|python3|`--enable-python3`|Build Python library integration|No|
+|python3|`--enable-python`|Build Python library integration|No|
 |pkg\_config\_path|`--with-pkgconfigdir`|`pkg-config` search directory|Set by Meson|
 
 As well, several directories can be configured, most importantly `prefix`. Non-standard directories you can change are `bashcompletiondir` and `zshcompletiondir`.

--- a/README.md
+++ b/README.md
@@ -293,12 +293,12 @@ You can use the following options at build time to influence the build. During t
 |png|`--with-png`|Whether to build with libpng support|Auto|
 |gcov|`--enable-gcov`|Build gcov coverage tests|No|
 |tests|`--enable-tests`|Build tests (requires `bash`)|No|
-|python2|`--enable-python`|Build Python library integration|No|
+|python3|`--enable-python3`|Build Python library integration|No|
 |pkg\_config\_path|`--with-pkgconfigdir`|`pkg-config` search directory|Set by Meson|
 
 As well, several directories can be configured, most importantly `prefix`. Non-standard directories you can change are `bashcompletiondir` and `zshcompletiondir`.
 
-Note: Before libsixel 2.0, Python was installed by default. This was disabled because it requires root on most systems for the Python module to be discoverable. Pass `-Dpython2=enabled` to install it.
+Note: Before libsixel 2.0, Python was installed by default. This was disabled because it requires root on most systems for the Python module to be discoverable. Pass `-Dpython3=enabled` to install it.
 
 ## Usage of command line tools
 

--- a/examples/python/converter.py
+++ b/examples/python/converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 from libsixel import *

--- a/meson.build
+++ b/meson.build
@@ -166,7 +166,7 @@ libsixel was configured as follows
     curl_dep.found(),
     bashcompletiondir,
     zshcompletiondir,
-    python3_installation.found().to_string(),
+    python3_dep.found().to_string(),
     get_option('buildtype'),
     get_option('tests').enabled()
   )

--- a/meson.build
+++ b/meson.build
@@ -87,10 +87,9 @@ gd_dep = cc.find_library('gd', required: get_option('gd'))
 curl_dep = dependency('libcurl', required: get_option('libcurl'))
 jpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
 png_dep = dependency('libpng', required: get_option('png'))
-pymod = import('python3')
-python3_installation = pymod.find_installation('python3', required: get_option('python3'))
+python3_dep = dependency('python3', required: get_option('python'))
 
-libsixel_deps = [libm_dep, curl_dep, jpeg_dep, png_dep, gd_dep, gdkpixbuf2_dep]
+libsixel_deps = [libm_dep, curl_dep, jpeg_dep, png_dep, gd_dep, gdkpixbuf2_dep, python3_dep]
 
 if curl_dep.found()
   conf_data.set('HAVE_LIBCURL', true)
@@ -142,7 +141,7 @@ subdir('src')
 subdir('converters')
 subdir('tools')
 
-if python3_installation.found()
+if python3_dep.found()
   subdir('python3')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -87,8 +87,8 @@ gd_dep = cc.find_library('gd', required: get_option('gd'))
 curl_dep = dependency('libcurl', required: get_option('libcurl'))
 jpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
 png_dep = dependency('libpng', required: get_option('png'))
-pymod = import('python')
-python2_installation = pymod.find_installation('python2', required: get_option('python2'))
+pymod = import('python3')
+python3_installation = pymod.find_installation('python3', required: get_option('python3'))
 
 libsixel_deps = [libm_dep, curl_dep, jpeg_dep, png_dep, gd_dep, gdkpixbuf2_dep]
 
@@ -142,8 +142,8 @@ subdir('src')
 subdir('converters')
 subdir('tools')
 
-if python2_installation.found()
-  subdir('python')
+if python3_installation.found()
+  subdir('python3')
 endif
 
 warning('Perl, PHP and Ruby modules are available but not installed by Meson. If you want them, please refer to their individual installation directories for instructions after building libsixel.')
@@ -167,7 +167,7 @@ libsixel was configured as follows
     curl_dep.found(),
     bashcompletiondir,
     zshcompletiondir,
-    python2_installation.found().to_string(),
+    python3_installation.found().to_string(),
     get_option('buildtype'),
     get_option('tests').enabled()
   )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,7 @@ option('jpeg', type: 'feature', value: 'auto', description: 'Whether to parse jp
 option('png', type: 'feature', value: 'auto', description: 'Whether to parse png inputs with libpng')
 option('tests', type: 'feature', value: 'disabled', description: 'Build tests')
 
-option('python2', type: 'feature', value: 'disabled', description: 'Whether to enable Python library integration (2.x+)')
+option('python3', type: 'feature', value: 'disabled', description: 'Whether to enable Python library integration (3.x+)')
 
 option('bashcompletiondir', type: 'string', value: '', description: 'Use the specified bash completion dir. Default: $datadir/bash-completion/completions')
 option('zshcompletiondir', type: 'string', value: '', description: 'Use the specified zsh completion dir. Default: $datadir/zsh/site-functions')

--- a/python/libsixel/__init__.py
+++ b/python/libsixel/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2014-2020 Hayaki Saito
 #

--- a/python/libsixel/decoder.py
+++ b/python/libsixel/decoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2014-2016 Hayaki Saito
 #
@@ -23,7 +23,7 @@
 from . import _sixel
 from libsixel import *
 
-class Decoder(object):
+class Decoder:
 
     def __init__(self):
         self._decoder = sixel_decoder_new()

--- a/python/libsixel/encoder.py
+++ b/python/libsixel/encoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2014-2016 Hayaki Saito
 #
@@ -23,7 +23,7 @@
 from . import _sixel
 from libsixel import *
 
-class Encoder(object):
+class Encoder:
 
     def __init__(self):
         self._encoder = sixel_encoder_new()

--- a/python/meson.build
+++ b/python/meson.build
@@ -4,4 +4,4 @@ sources = [
   'libsixel/decoder.py'
 ]
 
-python2_installation.install_sources(sources, subdir: join_paths([python2_installation.get_path('platlib'), 'libsixel']))
+python3_installation.install_sources(sources, subdir: join_paths([python3_installation.get_path('platlib'), 'libsixel']))

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-__version__ = '0.5.2'
+__version__ = '0.5.1'
 __license__ = 'MIT'
 __author__ = 'Hayaki Saito'
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-
 from setuptools import setup, find_packages
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __license__ = 'MIT'
 __author__ = 'Hayaki Saito'
 


### PR DESCRIPTION
Closes https://github.com/libsixel/libsixel/issues/33

I switched as many things as I could find to ensure python3 was explicitly used. Very little changes needed to actually get it running. If the build or CI are broke by one of the changes  for python, the commits are one file each so it's easy to fix up if needed. Let me know if what if anything needs changing. Also feel free to make edits as I'm no build expert if there is a problem. 

VSCode was giving linter warnings about things needing explicit imports but didn't mess with those to keep the changes minimal.

Also: I'd like to get a `pyproject.toml` running for the python bindings as I'd rather we switched from pip to poetry. I'd appreciate anybody who could help get that set up.