### PR TITLE
New API for safe(r) encoding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* libsixel 1.11 (not yet released)
+ * Resolve CVE-2020-36120 by marking `sixel_encoder_encode_bytes()` as
+   deprecated and unsafe. Replace it with `sixel_encoder_encode_buffer()`,
+   which takes an additional size argument, and can be used safely. The
+   former function will be removed in 1.12.
+
 * libsixel 1.10.2 (2021-10-08)
  * Update python bindings to use python3. Python 3.9 is preferred. File issues
    if bugs are found in python 3.6-8. Thanks, @wsluser

--- a/include/sixel.h.in
+++ b/include/sixel.h.in
@@ -31,6 +31,8 @@
 # define SIXELAPI
 #endif
 
+#define SIXELDEPRECATED __attribute__ ((deprecated))
+
 #define LIBSIXEL_VERSION "@PACKAGE_VERSION@"
 #define PACKAGE_VERSION LIBSIXEL_VERSION
 #define LIBSIXEL_ABI_VERSION "@LS_LTVERSION@"
@@ -708,10 +710,25 @@ SIXELAPI void
 sixel_dither_unref(sixel_dither_t *dither); /* dither context object */
 
 /* initialize internal palette from specified pixel buffer */
-SIXELAPI SIXELSTATUS
+/* this function is fundamentally unsafe. it has been disabled for
+ * libsixel 1.11, and will be removed entirely for libsixel 1.12.
+ * use sixel_dither_init() instead. */
+SIXELAPI SIXELSTATUS SIXELDEPRECATED
 sixel_dither_initialize(
     sixel_dither_t *dither,                    /* dither context object */
     unsigned char /* in */ *data,              /* sample image */
+    int           /* in */ width,              /* image width */
+    int           /* in */ height,             /* image height */
+    int           /* in */ pixelformat,        /* one of enum pixelFormat */
+    int           /* in */ method_for_largest, /* method for finding the largest dimension */
+    int           /* in */ method_for_rep,     /* method for choosing a color from the box */
+    int           /* in */ quality_mode);      /* quality of histogram processing */
+
+SIXELAPI SIXELSTATUS
+sixel_dither_init(
+    sixel_dither_t *dither,                    /* dither context object */
+    unsigned char /* in */ *data,              /* sample image */
+    int           /* in */ len,                /* number of bytes in data */
     int           /* in */ width,              /* image width */
     int           /* in */ height,             /* image height */
     int           /* in */ pixelformat,        /* one of enum pixelFormat */
@@ -796,9 +813,10 @@ extern "C" {
 SIXELAPI SIXELSTATUS
 sixel_encode(
     unsigned char  /* in */ *pixels,     /* pixel bytes */
-    int            /* in */  width,      /* image width */
-    int            /* in */  height,     /* image height */
-    int            /* in */  depth,      /* color depth: now unused */
+    int            /* in */ len,         /* source size in bytes */
+    int            /* in */ width,       /* image width */
+    int            /* in */ height,      /* image height */
+    int            /* in */ depth,       /* color depth: now unused */
     sixel_dither_t /* in */ *dither,     /* dither context */
     sixel_output_t /* in */ *context);   /* output context */
 
@@ -861,6 +879,7 @@ sixel_helper_normalize_pixelformat(
     unsigned char       /* out */ *dst,             /* destination buffer */
     int                 /* out */ *dst_pixelformat, /* converted pixelformat */
     unsigned char const /* in */  *src,             /* source pixels */
+    int                 /* in */  len,              /* size of src in bytes */
     int                 /* in */  src_pixelformat,  /* format of source image */
     int                 /* in */  width,            /* width of source image */
     int                 /* in */  height            /* height of source image */
@@ -952,6 +971,10 @@ sixel_frame_init(
 /* get pixels */
 SIXELAPI unsigned char *
 sixel_frame_get_pixels(sixel_frame_t /* in */ *frame);  /* frame object */
+
+/* get content length in bytes */
+SIXELAPI int
+sixel_frame_get_length(sixel_frame_t /* in */ *frame);  /* frame object */
 
 /* get palette */
 SIXELAPI unsigned char *
@@ -1100,8 +1123,12 @@ sixel_encoder_encode(
     char const      /* in */ *filename);
 
 /* encode specified pixel data to SIXEL format
- * output to encoder->outfd */
-SIXELAPI SIXELSTATUS
+ * output to encoder->outfd
+ * this function is *unsafe*! do not use it in new code! it will be removed
+ * in libsixel 1.12, and no longer works as of libsixel 1.11.
+ * use sixel_encoder_encode_buffer() instead.
+ **/
+SIXELAPI SIXELSTATUS SIXELDEPRECATED
 sixel_encoder_encode_bytes(
     sixel_encoder_t     /* in */    *encoder,
     unsigned char       /* in */    *bytes,
@@ -1111,6 +1138,19 @@ sixel_encoder_encode_bytes(
     unsigned char       /* in */    *palette,
     int                 /* in */    ncolors);
 
+/* encode specified pixel data having len bytes to SIXEL format
+ * output to encoder->outfd
+ **/
+SIXELAPI SIXELSTATUS
+sixel_encoder_encode_buffer(
+    sixel_encoder_t     /* in */    *encoder,
+    unsigned char       /* in */    *bytes,
+    int                 /* in */    len,
+    int                 /* in */    width,
+    int                 /* in */    height,
+    int                 /* in */    pixelformat,
+    unsigned char       /* in */    *palette,
+    int                 /* in */    ncolors);
 #ifdef __cplusplus
 }
 #endif

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ c_args = [
   '-Wunused-function',
   '-Wunused-but-set-variable',
   '-Bsymbolic',
+  '-g',
 ]
 
 foreach a : c_args

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libsixel', ['c'], version: '1.10.2', license: 'MIT', default_options: ['buildtype=release', 'c_std=c99', 'warning_level=3'])
+project('libsixel', ['c'], version: '1.11.0', license: 'MIT', default_options: ['buildtype=release', 'c_std=c99', 'warning_level=3'])
 
 datadir = get_option('datadir')
 if (get_option('bashcompletiondir') == '')

--- a/src/dither.c
+++ b/src/dither.c
@@ -514,6 +514,32 @@ sixel_dither_initialize(
     int             /* in */ method_for_rep,
     int             /* in */ quality_mode)
 {
+    (void)dither;
+    (void)data;
+    (void)width;
+    (void)height;
+    (void)pixelformat;
+    (void)method_for_largest;
+    (void)method_for_rep;
+    (void)quality_mode;
+    fprintf(stderr, "sixel_dither_initialize() has been disabled, as it"
+            " is unsafe.\nuse sixel_dither_init() instead.\n");
+    return SIXEL_FALSE;
+}
+
+
+SIXELAPI SIXELSTATUS
+sixel_dither_init(
+    sixel_dither_t  /* in */ *dither,
+    unsigned char   /* in */ *data,
+    int             /* in */ len,
+    int             /* in */ width,
+    int             /* in */ height,
+    int             /* in */ pixelformat,
+    int             /* in */ method_for_largest,
+    int             /* in */ method_for_rep,
+    int             /* in */ quality_mode)
+{
     unsigned char *buf = NULL;
     unsigned char *normalized_pixels = NULL;
     unsigned char *input_pixels;
@@ -551,6 +577,7 @@ sixel_dither_initialize(
             normalized_pixels,
             &pixelformat,
             data,
+            len,
             pixelformat,
             width,
             height);
@@ -719,6 +746,7 @@ SIXELAPI sixel_index_t *
 sixel_dither_apply_palette(
     sixel_dither_t  /* in */ *dither,
     unsigned char   /* in */ *pixels,
+    int             /* in */ len,
     int             /* in */ width,
     int             /* in */ height)
 {
@@ -779,7 +807,7 @@ sixel_dither_apply_palette(
         }
         status = sixel_helper_normalize_pixelformat(normalized_pixels,
                                                     &dither->pixelformat,
-                                                    pixels, dither->pixelformat,
+                                                    pixels, len, dither->pixelformat,
                                                     width, height);
         if (SIXEL_FAILED(status)) {
             goto end;

--- a/src/dither.h
+++ b/src/dither.h
@@ -54,6 +54,7 @@ extern "C" {
 sixel_index_t *
 sixel_dither_apply_palette(struct sixel_dither /* in */ *dither,
                            unsigned char       /* in */ *pixels,
+                           int                 /* in */ len,
                            int                 /* in */ width,
                            int                 /* in */ height);
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -178,6 +178,7 @@ sixel_frame_init(
     frame->pixelformat = pixelformat;
     frame->palette = palette;
     frame->ncolors = ncolors;
+    frame->len = 0;
 
     status = SIXEL_OK;
 
@@ -193,6 +194,14 @@ SIXELAPI unsigned char *
 sixel_frame_get_pixels(sixel_frame_t /* in */ *frame)  /* frame object */
 {
     return frame->pixels;
+}
+
+
+/* get content length */
+SIXELAPI int
+sixel_frame_get_length(sixel_frame_t /* in */ *frame)  /* frame object */
+{
+    return frame->len;
 }
 
 
@@ -418,6 +427,7 @@ sixel_frame_convert_to_rgb888(sixel_frame_t /*in */ *frame)
         status = sixel_helper_normalize_pixelformat(src,
                                                     &frame->pixelformat,
                                                     frame->pixels,
+                                                    size,
                                                     frame->pixelformat,
                                                     frame->width,
                                                     frame->height);
@@ -477,6 +487,7 @@ sixel_frame_convert_to_rgb888(sixel_frame_t /*in */ *frame)
         status = sixel_helper_normalize_pixelformat(normalized_pixels,
                                                     &frame->pixelformat,
                                                     frame->pixels,
+                                                    frame->len,
                                                     frame->pixelformat,
                                                     frame->width,
                                                     frame->height);
@@ -704,6 +715,7 @@ sixel_frame_clip(
         status = sixel_helper_normalize_pixelformat(normalized_pixels,
                                                     &frame->pixelformat,
                                                     frame->pixels,
+                                                    frame->len,
                                                     frame->pixelformat,
                                                     frame->width,
                                                     frame->height);

--- a/src/frame.h
+++ b/src/frame.h
@@ -28,6 +28,7 @@
 struct sixel_frame {
     unsigned int ref;               /* reference counter */
     unsigned char *pixels;          /* loaded pixel data */
+    int len;                        /* loaded content bytes */
     unsigned char *palette;         /* loaded palette data */
     int width;                      /* frame width */
     int height;                     /* frame height */

--- a/src/fromgif.c
+++ b/src/fromgif.c
@@ -649,6 +649,7 @@ load_gif(
         frame->frame_no = 0;
 
         s.img_buffer = s.img_buffer_original;
+        // FIXME verify size is sufficient for headers
         status = gif_load_header(&s, &g);
         if (status != SIXEL_OK) {
             goto end;
@@ -672,6 +673,7 @@ load_gif(
                 goto end;
             }
 
+            // FIXME drop header/footer length from size
             status = fnp.fn(frame, context);
             if (status != SIXEL_OK) {
                 goto end;

--- a/src/loader.c
+++ b/src/loader.c
@@ -262,6 +262,7 @@ load_png(unsigned char      /* out */ **result,
          int                /* out */ *transparent,
          sixel_allocator_t  /* in */  *allocator)
 {
+fprintf(stderr, "SIZE: %d\n", size);
     SIXELSTATUS status;
     sixel_chunk_t read_chunk;
     png_uint_32 bitdepth;
@@ -622,6 +623,7 @@ load_sixel(unsigned char        /* out */ **result,
     int colors;
     int i;
 
+fprintf(stderr, "SIZE: %d\n", size);
     /* sixel */
     status = sixel_decode_raw(buffer, size,
                               &p, psx, psy,
@@ -890,6 +892,7 @@ load_with_builtin(
         if (SIXEL_FAILED(status)) {
             goto end;
         }
+        frame->len = pchunk->size;
         stbi_allocator = pchunk->allocator;
         stbi__start_mem(&s, pchunk->buffer, (int)pchunk->size);
         frame->pixels = stbi__load_and_postprocess_8bit(&s, &frame->width, &frame->height, &depth, 3);
@@ -1274,6 +1277,7 @@ load_with_gd(
 #endif
     }
 
+    frame->size = pchunk->size;
     frame->width = gdImageSX(im);
     frame->height = gdImageSY(im);
     frame->pixelformat = SIXEL_PIXELFORMAT_RGB888;

--- a/src/loader.c
+++ b/src/loader.c
@@ -262,7 +262,6 @@ load_png(unsigned char      /* out */ **result,
          int                /* out */ *transparent,
          sixel_allocator_t  /* in */  *allocator)
 {
-fprintf(stderr, "SIZE: %d\n", size);
     SIXELSTATUS status;
     sixel_chunk_t read_chunk;
     png_uint_32 bitdepth;
@@ -623,7 +622,6 @@ load_sixel(unsigned char        /* out */ **result,
     int colors;
     int i;
 
-fprintf(stderr, "SIZE: %d\n", size);
     /* sixel */
     status = sixel_decode_raw(buffer, size,
                               &p, psx, psy,

--- a/src/pixelformat.c
+++ b/src/pixelformat.c
@@ -176,6 +176,7 @@ expand_rgb(unsigned char *dst,
     int src_offset;
     unsigned char r, g, b;
 
+    fprintf(stderr, "WxH: %dx%d pf: %d depth: %d\n", width, height, pixelformat, depth);
     for (y = 0; y < height; y++) {
         for (x = 0; x < width; x++) {
             src_offset = depth * (y * width + x);
@@ -259,6 +260,7 @@ sixel_helper_normalize_pixelformat(
     unsigned char       /* out */ *dst,             /* destination buffer */
     int                 /* out */ *dst_pixelformat, /* converted pixelformat */
     unsigned char const /* in */  *src,             /* source pixels */
+    int                 /* in */  len,              /* size of source in bytes */
     int                 /* in */  src_pixelformat,  /* format of source image */
     int                 /* in */  width,            /* width of source image */
     int                 /* in */  height)           /* height of source image */
@@ -267,6 +269,9 @@ sixel_helper_normalize_pixelformat(
 
     switch (src_pixelformat) {
     case SIXEL_PIXELFORMAT_G8:
+        if (len < width * height) {
+            return SIXEL_FALSE;
+        }
         expand_rgb(dst, src, width, height, src_pixelformat, 1);
         *dst_pixelformat = SIXEL_PIXELFORMAT_RGB888;
         break;
@@ -276,11 +281,17 @@ sixel_helper_normalize_pixelformat(
     case SIXEL_PIXELFORMAT_BGR555:
     case SIXEL_PIXELFORMAT_GA88:
     case SIXEL_PIXELFORMAT_AG88:
+        if (len < width * height * 2) {
+            return SIXEL_FALSE;
+        }
         expand_rgb(dst, src, width, height, src_pixelformat, 2);
         *dst_pixelformat = SIXEL_PIXELFORMAT_RGB888;
         break;
     case SIXEL_PIXELFORMAT_RGB888:
     case SIXEL_PIXELFORMAT_BGR888:
+        if (len < width * height * 3) {
+            return SIXEL_FALSE;
+        }
         expand_rgb(dst, src, width, height, src_pixelformat, 3);
         *dst_pixelformat = SIXEL_PIXELFORMAT_RGB888;
         break;
@@ -288,6 +299,9 @@ sixel_helper_normalize_pixelformat(
     case SIXEL_PIXELFORMAT_ARGB8888:
     case SIXEL_PIXELFORMAT_BGRA8888:
     case SIXEL_PIXELFORMAT_ABGR8888:
+        if (len < width * height * 4) {
+            return SIXEL_FALSE;
+        }
         expand_rgb(dst, src, width, height, src_pixelformat, 4);
         *dst_pixelformat = SIXEL_PIXELFORMAT_RGB888;
         break;

--- a/src/scale.c
+++ b/src/scale.c
@@ -325,9 +325,10 @@ sixel_helper_scale_image(
         if (new_src == NULL) {
             return (-1);
         }
+        int len = srcw * srch * depth;
         nret = sixel_helper_normalize_pixelformat(new_src,
                                                   &new_pixelformat,
-                                                  src, pixelformat,
+                                                  src, len, pixelformat,
                                                   srcw, srch);
         if (nret != 0) {
             sixel_allocator_free(allocator, new_src);

--- a/src/tosixel.c
+++ b/src/tosixel.c
@@ -881,6 +881,7 @@ sixel_encode_body_ormode(
 static SIXELSTATUS
 sixel_encode_dither(
     unsigned char   /* in */ *pixels,   /* pixel bytes to be encoded */
+    int             /* in */ len,       /* source size in bytes */
     int             /* in */ width,     /* width of source image */
     int             /* in */ height,    /* height of source image */
     sixel_dither_t  /* in */ *dither,   /* dither context */
@@ -909,6 +910,7 @@ sixel_encode_dither(
         status = sixel_helper_normalize_pixelformat(paletted_pixels,
                                                     &dither->pixelformat,
                                                     pixels,
+                                                    len,
                                                     dither->pixelformat,
                                                     width, height);
         if (SIXEL_FAILED(status)) {
@@ -924,7 +926,7 @@ sixel_encode_dither(
         break;
     default:
         /* apply palette */
-        paletted_pixels = sixel_dither_apply_palette(dither, pixels,
+        paletted_pixels = sixel_dither_apply_palette(dither, pixels, len,
                                                      width, height);
         if (paletted_pixels == NULL) {
             status = SIXEL_RUNTIME_ERROR;
@@ -1410,7 +1412,7 @@ sixel_apply_15bpp_dither(
 
 static SIXELSTATUS
 sixel_encode_highcolor(
-        unsigned char *pixels, int width, int height,
+        unsigned char *pixels, int len, int width, int height,
         sixel_dither_t *dither, sixel_output_t *output
         )
 {
@@ -1450,6 +1452,7 @@ sixel_encode_highcolor(
         status = sixel_helper_normalize_pixelformat(normalized_pixels,
                                                     &dither->pixelformat,
                                                     pixels,
+                                                    len,
                                                     dither->pixelformat,
                                                     width, height);
         if (SIXEL_FAILED(status)) {
@@ -1622,6 +1625,7 @@ error:
 SIXELAPI SIXELSTATUS
 sixel_encode(
     unsigned char  /* in */ *pixels,   /* pixel bytes */
+    int            /* in */ len,       /* source size in bytes */
     int            /* in */ width,     /* image width */
     int            /* in */ height,    /* image height */
     int const      /* in */ depth,     /* color depth */
@@ -1653,10 +1657,10 @@ sixel_encode(
     }
 
     if (dither->quality_mode == SIXEL_QUALITY_HIGHCOLOR) {
-        status = sixel_encode_highcolor(pixels, width, height,
+        status = sixel_encode_highcolor(pixels, len, width, height,
                                         dither, output);
     } else {
-        status = sixel_encode_dither(pixels, width, height,
+        status = sixel_encode_dither(pixels, len, width, height,
                                      dither, output);
     }
 

--- a/src/writer.c
+++ b/src/writer.c
@@ -100,6 +100,7 @@ write_png_to_file(
         status = sixel_helper_normalize_pixelformat(src,
                                                     &pixelformat,
                                                     data,
+                                                    width * height * 3,
                                                     pixelformat,
                                                     width, height);
         if (SIXEL_FAILED(status)) {
@@ -180,6 +181,7 @@ write_png_to_file(
         status = sixel_helper_normalize_pixelformat(pixels,
                                                     &pixelformat,
                                                     data,
+                                                    width * height * 3,
                                                     pixelformat,
                                                     width, height);
         if (SIXEL_FAILED(status)) {


### PR DESCRIPTION
#46 shows sample code that dances fandango on core with the existing libsixel (and is an outstanding CVE). This PR deprecates the existing API, which could never be properly used (it didn't accept a length parameter for the incoming buffer against which the internally-expressed geometries could be checked). Add new forms of the deprecated functions accepting a length parameter. Exit if the length is insufficient. I doubt that this is entirely correct, or as precise as it could be, but it does seem to resolve the issue, and I've already spent more time on this busted library than I care to.

I'd love to see someone run some more tests against it before we merge.

We want an ABI bump for this, most likely (did I disable the old functions, or just deprecate them? If it's the latter, we don't technically need one).