### PR TITLE
There is no HAS_LIBPNG

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -36,9 +36,9 @@
 #ifdef HAVE_GD
 # include <gd.h>
 #endif
-#ifdef HAVE_LIBPNG
+#ifdef HAVE_PNG
 # include <png.h>
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
 #ifdef HAVE_JPEG
 # include <jpeglib.h>
 #endif  /* HAVE_JPEG */
@@ -81,10 +81,8 @@ stbi_free(void *p)
 #define STBI_NO_GIF
 #define STBI_NO_PNM
 
-#ifdef HAVE_DIAGNOSTIC_SIGN_CONVERSION
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wstrict-overflow"
 # pragma GCC diagnostic push
@@ -182,7 +180,7 @@ end:
 # endif  /* HAVE_JPEG */
 
 
-# if HAVE_LIBPNG
+# ifdef HAVE_PNG
 static void
 read_png(png_structp png_ptr,
          png_bytep data,
@@ -601,7 +599,7 @@ cleanup:
 }
 # pragma GCC diagnostic pop
 
-# endif  /* HAVE_LIBPNG */
+# endif  /* HAVE_PNG */
 
 
 static SIXELSTATUS
@@ -713,7 +711,7 @@ chunk_is_pnm(sixel_chunk_t const *chunk)
 }
 
 
-#ifdef HAVE_LIBPNG
+#ifdef HAVE_PNG
 /* detect whether given chunk is PNG stream */
 static int
 chunk_is_png(sixel_chunk_t const *chunk)
@@ -726,7 +724,7 @@ chunk_is_png(sixel_chunk_t const *chunk)
     }
     return 0;
 }
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
 
 
 /* detect whether given chunk is GIF stream */
@@ -843,7 +841,7 @@ load_with_builtin(
         }
     }
 #endif  /* HAVE_JPEG */
-#ifdef HAVE_LIBPNG
+#ifdef HAVE_PNG
     else if (chunk_is_png(pchunk)) {
         status = sixel_frame_new(&frame, pchunk->allocator);
         if (SIXEL_FAILED(status)) {
@@ -865,7 +863,7 @@ load_with_builtin(
             goto end;
         }
     }
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
     else if (chunk_is_gif(pchunk)) {
         fnp.fn = fn_load;
         status = load_gif(pchunk->buffer,

--- a/src/status.c
+++ b/src/status.c
@@ -153,7 +153,7 @@ sixel_helper_format_error(
             error_string = SIXEL_MESSAGE_JPEG_ERROR;
             break;
 #endif
-#ifdef HAVE_LIBPNG
+#ifdef HAVE_PNG
         case SIXEL_PNG_ERROR:
             error_string = SIXEL_MESSAGE_PNG_ERROR;
             break;
@@ -273,7 +273,7 @@ test2(void)
     }
 #endif
 
-#ifdef HAVE_LIBPNG
+#ifdef HAVE_PNG
     message = sixel_helper_format_error(SIXEL_PNG_ERROR);
     if (strcmp(message, SIXEL_MESSAGE_PNG_ERROR) != 0) {
         goto error;

--- a/src/writer.c
+++ b/src/writer.c
@@ -25,15 +25,15 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
-#if HAVE_SETJMP_H
+#ifdef HAVE_SETJMP_H
 # include <setjmp.h>
 #endif  /* HAVE_SETJMP_H */
 # include <errno.h>
-#if HAVE_LIBPNG
+#ifdef HAVE_PNG
 # include <png.h>
 #else
 # include "stb_image_write.h"
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
 
 #include <sixel.h>
 
@@ -43,12 +43,6 @@
 # define O_BINARY _O_BINARY
 #endif  /* !defined(O_BINARY) && !defined(_O_BINARY) */
 
-
-#if !HAVE_LIBPNG
-unsigned char *
-stbi_write_png_to_mem(unsigned char *pixels, int stride_bytes,
-                      int x, int y, int n, int *out_len);
-#endif
 
 static SIXELSTATUS
 write_png_to_file(
@@ -64,7 +58,7 @@ write_png_to_file(
     FILE *output_fp = NULL;
     unsigned char *pixels = NULL;
     unsigned char *new_pixels = NULL;
-#if HAVE_LIBPNG
+#ifdef HAVE_PNG
     int y;
     png_structp png_ptr = NULL;
     png_infop info_ptr = NULL;
@@ -73,7 +67,7 @@ write_png_to_file(
     unsigned char *png_data = NULL;
     int png_len;
     int write_len;
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
     int i;
     unsigned char *src;
     unsigned char *dst;
@@ -211,7 +205,7 @@ write_png_to_file(
         }
     }
 
-#if HAVE_LIBPNG
+#ifdef HAVE_PNG
     rows = sixel_allocator_malloc(allocator, (size_t)height * sizeof(unsigned char *));
     if (rows == NULL) {
         status = SIXEL_BAD_ALLOCATION;
@@ -263,7 +257,7 @@ write_png_to_file(
         sixel_helper_set_additional_message("fwrite() failed.");
         goto end;
     }
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
 
     status = SIXEL_OK;
 
@@ -271,14 +265,14 @@ end:
     if (output_fp && output_fp != stdout) {
         fclose(output_fp);
     }
-#if HAVE_LIBPNG
+#ifdef HAVE_PNG
     sixel_allocator_free(allocator, rows);
     if (png_ptr) {
         png_destroy_write_struct(&png_ptr, &info_ptr);
     }
 #else
     sixel_allocator_free(allocator, png_data);
-#endif  /* HAVE_LIBPNG */
+#endif  /* HAVE_PNG */
     sixel_allocator_free(allocator, new_pixels);
 
     return status;


### PR DESCRIPTION
about half of the compilation checks were using `HAVE_LIBPNG`, and the other half were using `HAVE_PNG`. converge on `HAVE_PNG`, matching the other declarations in config.h.