### PR TITLE
fix non unix builds (headers)

### DIFF
--- a/converters/img2sixel.c
+++ b/converters/img2sixel.c
@@ -32,8 +32,9 @@
 # include <getopt.h>
 # include <inttypes.h>
 # include <signal.h>
+#if HAVE_SYS_SIGNAL_H
 # include <sys/signal.h>
-
+#endif
 #include <sixel.h>
 
 /* output version info to STDOUT */
@@ -311,6 +312,7 @@ void show_help(void)
             );
 }
 
+#if HAVE_SYS_SIGNAL_H
 
 static int signaled = 0;
 
@@ -320,6 +322,7 @@ signal_handler(int sig)
     signaled = sig;
 }
 
+#endif
 
 int
 main(int argc, char *argv[])
@@ -413,6 +416,8 @@ main(int argc, char *argv[])
         }
     }
 
+#if HAVE_SYS_SIGNAL_H
+
     /* set signal handler to handle SIGINT/SIGTERM/SIGHUP */
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
@@ -421,6 +426,8 @@ main(int argc, char *argv[])
     if (SIXEL_FAILED(status)) {
         goto error;
     }
+
+#endif
 
     if (optind == argc) {
         status = sixel_encoder_encode(encoder, NULL);

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libsixel', ['c'], version: '1.10.2', license: 'MIT', default_options: ['buildtype=release', 'c_std=c99', 'warning_level=3'])
+project('libsixel', ['c'], version: '1.10.3', license: 'MIT', default_options: ['buildtype=release', 'c_std=c99', 'warning_level=3'])
 
 datadir = get_option('datadir')
 if (get_option('bashcompletiondir') == '')
@@ -64,10 +64,6 @@ needed_headers = [
   'sys/time.h',
   'time.h',
   'signal.h',
-  'sys/select.h',
-  'sys/signal.h',
-  'termios.h',
-  'sys/ioctl.h',
   'inttypes.h'
 ]
 
@@ -79,6 +75,11 @@ have_getopt_long = cc.has_function('getopt_long')
 foreach a : needed_headers
   assert(cc.has_header(a), 'Needed header not found')
 endforeach
+
+conf_data.set10('HAVE_SYS_SELECT_H', cc.has_header('sys/select.h'))
+conf_data.set10('HAVE_SYS_SIGNAL_H', cc.has_header('sys/signal.h'))
+conf_data.set10('HAVE_SYS_IOCTL_H', cc.has_header('sys/ioctl.h'))
+conf_data.set10('HAVE_TERMIOS_H', cc.has_header('termios.h'))
 
 libm_dep = cc.find_library('m', required: false)
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -32,8 +32,10 @@
 # include <errno.h>
 #ifdef HAVE_LIBCURL
 # include <curl/curl.h>
-#endif  /* HAVE_LIBCURL */
+#endif
+#if HAVE_SYS_SELECT_H
 # include <sys/select.h>
+#endif
 
 
 
@@ -141,6 +143,7 @@ static int
 wait_file(int fd, int usec)
 {
     int ret = 1;
+#if HAVE_SYS_SELECT_H
     fd_set rfds;
     struct timeval tv;
 
@@ -149,6 +152,10 @@ wait_file(int fd, int usec)
     FD_ZERO(&rfds);
     FD_SET(fd, &rfds);
     ret = select(fd + 1, &rfds, NULL, NULL, &tv);
+#else
+    (void) fd;
+    (void) usec;
+#endif
     if (ret == 0) {
         return (1);
     }

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -26,17 +26,23 @@
 # include <stdarg.h>
 # include <string.h>
 # include <unistd.h>
-#include <sys/types.h>
-#include <sys/select.h>
+# include <sys/types.h>
+#if HAVE_SYS_SELECT_H
+# include <sys/select.h>
+#endif
 # include <time.h>
 # include <sys/time.h>
 # include <inttypes.h>
 # include <errno.h>
+#if HAVE_TERMIOS_H
 # include <termios.h>
+#endif
+#if HAVE_SYS_IOCTL_H
 # include <sys/ioctl.h>
+#endif
 #if HAVE_IO_H
 # include <io.h>
-#endif  /* HAVE_IO_H */
+#endif
 
 #include "decoder.h"
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -28,10 +28,16 @@
 # include <sys/time.h>
 # include <sys/types.h>
 # include <unistd.h>
+#if HAVE_SYS_SELECT_H
 # include <sys/select.h>
+#endif
 # include <errno.h>
+#if HAVE_TERMIOS_H
 # include <termios.h>
+#endif
+#if HAVE_SYS_IOCTL_H
 # include <sys/ioctl.h>
+#endif
 
 #include <sixel.h>
 
@@ -98,10 +104,11 @@ end:
 SIXELSTATUS
 sixel_tty_wait_stdin(int usec)
 {
+    SIXELSTATUS status = SIXEL_FALSE;
+#if HAVE_SYS_SELECT_H
     fd_set rfds;
     struct timeval tv;
     int ret = 0;
-    SIXELSTATUS status = SIXEL_FALSE;
 
     tv.tv_sec = usec / 1000000;
     tv.tv_usec = usec % 1000000;
@@ -117,6 +124,10 @@ sixel_tty_wait_stdin(int usec)
 
     /* success */
     status = SIXEL_OK;
+#else
+    (void) usec;
+    goto end;
+#endif
 
 end:
     return status;


### PR DESCRIPTION
Fix `windows` `mingw` build, which was ok before the `meson` transition.

Needed for https://github.com/JuliaPackaging/Yggdrasil/pull/5432.

I've read https://github.com/saitoha/libsixel/issues/154, and I have to thank @ctrlcctrlv for taking the lead on the abandoned https://github.com/saitoha/libsixel (which is never a good thing). These days, choosing `meson` is the right move, it is worth the effort.

Thanks all for maintaining `libsixel` and moving forward !
